### PR TITLE
Refs #16740 - Update all templates to use params macros

### DIFF
--- a/Kickstart_Default_PXELinux_FIPS.erb
+++ b/Kickstart_Default_PXELinux_FIPS.erb
@@ -22,7 +22,7 @@ kernel <%= @kernel %>
 <% if @host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16 -%>
 append initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ks.device=bootif network ks.sendmac
 <% elsif @host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7 -%>
-append initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> network ks.sendmac <% if @host.params['fips_enabled'] == 'true' %>fips=1
+append initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> network ks.sendmac <% if host_param('fips_enabled') == 'true' %>fips=1
 <% end -%>
 <% else -%>
 append initrd=<%= @initrd %> ks=<%= foreman_url('provision')%> ksdevice=bootif network kssendmac

--- a/Satellite_Kickstart_Default_FIPS.erb
+++ b/Satellite_Kickstart_Default_FIPS.erb
@@ -11,8 +11,8 @@ oses:
   os_major = @host.operatingsystem.major.to_i
   # safemode renderer does not support unary negation
   pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || @host.params['force-puppet']
-  salt_enabled = @host.params['salt_master'] ? true : false
+  puppet_enabled = pm_set || host_param('force-puppet')
+  salt_enabled = host_param('salt_master') ? true : false
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
 %>
 install
@@ -34,7 +34,7 @@ network --bootproto <%= dhcp ? 'dhcp' : "static --ip=#{@host.ip} --netmask=#{sub
 rootpw --iscrypted <%= root_pass %>
 firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
 authconfig --useshadow --passalgo=sha256 --kickstart
-timezone --utc <%= @host.params['time-zone'] || 'UTC' %>
+timezone --utc <%= host_param('time-zone') || 'UTC' %>
 
 <% if @host.operatingsystem.name == 'Fedora' and os_major <= 16 -%>
 # Bootloader exception for Fedora 16:
@@ -63,7 +63,7 @@ dhclient
 ntp
 wget
 @Core
-<%if @host.params['fips_enabled'] == 'true' %> 
+<%if host_param('fips_enabled') == 'true' %> 
 <%= snippet "fips_packages" %>
 <% end -%>
 
@@ -98,7 +98,7 @@ exec < /dev/tty3 > /dev/tty3
 
 #update local time
 echo "updating system time"
-/usr/sbin/ntpdate -sub <%= @host.params['ntp-server'] || '0.fedora.pool.ntp.org' %>
+/usr/sbin/ntpdate -sub <%= host_param('ntp-server') || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 
 <%= snippet "subscription_manager_registration" %>


### PR DESCRIPTION
Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1683350

also is there a reason, why these templates don't live in community templates? This way they would be updated as part of https://github.com/theforeman/community-templates/commit/227ccb5ff717b30a31eb03c752b1d1ad5ed55e6e and we wouldn't have to wait for QE to find it.